### PR TITLE
Add Workflow Trigger to Update GitHub User Pages

### DIFF
--- a/.github/workflows/trigger-user-pages.yml
+++ b/.github/workflows/trigger-user-pages.yml
@@ -1,0 +1,18 @@
+name: Trigger user-site rebuild
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fire repository_dispatch to ferdihs.github.io
+        run: |
+          curl -L -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.PAGES_DISPATCH_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/FerdiHS/ferdihs.github.io/dispatches \
+            -d '{"event_type":"rebuild-site","client_payload":{"source_repo":"FerdiHS/ferdihs","ref":"${{ github.ref }}","sha":"${{ github.sha }}"}}'

--- a/public/profile.json
+++ b/public/profile.json
@@ -155,7 +155,7 @@
   },
   "awards": [
     {
-      "text": "Rated 1746 in",
+      "text": "Rated 1805 in",
       "link": {
         "label": "Codeforces",
         "url": "https://codeforces.com/profile/FerdiHS"


### PR DESCRIPTION
This pull request introduces an automated workflow to trigger a rebuild of the user site whenever changes are pushed to the `main` branch, and updates the displayed Codeforces rating in the user profile.

**Automation and profile update:**

* Added a new GitHub Actions workflow in `.github/workflows/trigger-user-pages.yml` to automatically send a dispatch event to the `ferdihs.github.io` repository on every push to `main`, enabling automatic site rebuilds.

* Updated the Codeforces rating displayed in `public/profile.json` from 1746 to 1805 to reflect the latest achievement.